### PR TITLE
Build with the argtable3 lib sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set( CMAKE_INSTALL_PREFIX /usr )
 
 include_directories(.)
 
+add_library( argtable3 argtable3.c argtable3.h )
 
 add_executable( hashstrings
                 hashstrings.c    hashstrings.h


### PR DESCRIPTION
The repo already has `argtable3.c` and `argtable3.h` amalgamation source files, but CMake is not using them? 
So the build fails unless `libargtable3` is already available on the system. Even if it is, the toolchain can't take advantage of inter-process optimization available with the amalgamated sources. 

Please add this line to the build so the project can be built on systems where `libargtable3` is unavailable.